### PR TITLE
 Bringing config_src updates from esmg

### DIFF
--- a/config_src/external/GFDL_ocean_BGC/generic_tracer.F90
+++ b/config_src/external/GFDL_ocean_BGC/generic_tracer.F90
@@ -6,6 +6,8 @@ module generic_tracer
 
   use g_tracer_utils, only : g_tracer_type, g_diag_type
 
+  use MOM_variables, only : thermo_var_ptrs
+
   implicit none ; private
 
   public generic_tracer_register
@@ -32,7 +34,8 @@ contains
   end subroutine generic_tracer_register
 
   !> Initialize generic tracers
-  subroutine generic_tracer_init(isc,iec,jsc,jec,isd,ied,jsd,jed,nk,ntau,axes,grid_tmask,grid_kmt,init_time)
+  subroutine generic_tracer_init(isc,iec,jsc,jec,isd,ied,jsd,jed,nk,ntau,axes,grid_tmask,grid_kmt,init_time, &
+                                 geolon,geolat)
     integer,                       intent(in) :: isc !< Computation start index in i direction
     integer,                       intent(in) :: iec !< Computation end index in i direction
     integer,                       intent(in) :: jsc !< Computation start index in j direction
@@ -47,6 +50,8 @@ contains
     type(time_type),               intent(in) :: init_time !< Time
     real, dimension(:,:,:),target, intent(in) :: grid_tmask !< Mask
     integer, dimension(:,:)      , intent(in) :: grid_kmt !< Number of wet cells in column
+    real, dimension(:,:),target,   intent(in) :: geolon !< Longitude
+    real, dimension(:,:),target,   intent(in) :: geolat !< Latitude
   end subroutine generic_tracer_init
 
   !> Unknown
@@ -66,13 +71,15 @@ contains
   end subroutine generic_tracer_coupler_accumulate
 
   !> Calls the corresponding generic_X_update_from_source routine for each package X
-  subroutine generic_tracer_source(Temp,Salt,rho_dzt,dzt,hblt_depth,ilb,jlb,tau,dtts,&
+  subroutine generic_tracer_source(Temp,Salt,tv,rho_dzt,dzt,hblt_depth,ilb,jlb,tau,dtts,&
        grid_dat,model_time,nbands,max_wavelength_band,sw_pen_band,opacity_band,internal_heat,&
        frunoff,grid_ht, current_wave_stress, sosga)
     integer,                        intent(in) :: ilb    !< Lower bounds of x extent of input arrays on data domain
     integer,                        intent(in) :: jlb    !< Lower bounds of y extent of input arrays on data domain
     real, dimension(ilb:,jlb:,:),   intent(in) :: Temp   !< Potential temperature [deg C]
     real, dimension(ilb:,jlb:,:),   intent(in) :: Salt   !< Salinity [psu]
+    type(thermo_var_ptrs),          intent(in) :: tv     !< structure containing pointers to available
+                                                         !! thermodynamic fields
     real, dimension(ilb:,jlb:,:),   intent(in) :: rho_dzt !< Mass per unit area of each layer [kg m-2]
     real, dimension(ilb:,jlb:,:),   intent(in) :: dzt    !< Ocean layer thickness [m]
     real, dimension(ilb:,jlb:),     intent(in) :: hblt_depth !< Boundary layer depth [m]

--- a/config_src/external/GFDL_ocean_BGC/generic_tracer_utils.F90
+++ b/config_src/external/GFDL_ocean_BGC/generic_tracer_utils.F90
@@ -108,7 +108,8 @@ contains
     type(g_diag_ctrl),  target,intent(in) :: diag_CS !< Unknown
   end subroutine g_tracer_set_csdiag
 
-  subroutine g_tracer_set_common(isc,iec,jsc,jec,isd,ied,jsd,jed,nk,ntau,axes,grid_tmask,grid_kmt,init_time)
+  subroutine g_tracer_set_common(isc,iec,jsc,jec,isd,ied,jsd,jed,nk,ntau,axes,grid_tmask,grid_kmt,init_time, &
+                                 geolon,geolat)
     integer,                     intent(in) :: isc !< Computation start index in i direction
     integer,                     intent(in) :: iec !< Computation end index in i direction
     integer,                     intent(in) :: jsc !< Computation start index in j direction
@@ -123,6 +124,8 @@ contains
     real, dimension(isd:,jsd:,:),intent(in) :: grid_tmask !< Unknown
     integer,dimension(isd:,jsd:),intent(in) :: grid_kmt !< Unknown
     type(time_type),             intent(in) :: init_time !< Unknown
+    real, dimension(isd:,jsd:),  intent(in) :: geolon !< Longitude
+    real, dimension(isd:,jsd:),  intent(in) :: geolat !< Latitude
   end subroutine g_tracer_set_common
 
   subroutine g_tracer_get_common(isc,iec,jsc,jec,isd,ied,jsd,jed,nk,ntau,&


### PR DESCRIPTION
 - otherwise it doesn't compile without linking to COBALT due to COBALT interface updates.