### PR TITLE
Simplify changes to the generic tracer interface for cobalt-p4

### DIFF
--- a/config_src/external/GFDL_ocean_BGC/generic_tracer.F90
+++ b/config_src/external/GFDL_ocean_BGC/generic_tracer.F90
@@ -70,7 +70,7 @@ contains
   !> Calls the corresponding generic_X_update_from_source routine for each package X
   subroutine generic_tracer_source(Temp,Salt,rho_dzt,dzt,hblt_depth,ilb,jlb,tau,dtts,&
        grid_dat,model_time,nbands,max_wavelength_band,sw_pen_band,opacity_band,internal_heat,&
-       frunoff,grid_ht, current_wave_stress, sosga, eqn_of_state)
+       frunoff,grid_ht, current_wave_stress, sosga, geolat, eqn_of_state)
     integer,                        intent(in) :: ilb    !< Lower bounds of x extent of input arrays on data domain
     integer,                        intent(in) :: jlb    !< Lower bounds of y extent of input arrays on data domain
     real, dimension(ilb:,jlb:,:),   intent(in) :: Temp   !< Potential temperature [deg C]
@@ -96,6 +96,7 @@ contains
     real, dimension(ilb:,jlb:),optional,  intent(in) :: grid_ht !< Unknown, and presently unused by MOM6
     real, dimension(ilb:,jlb:),optional , intent(in) :: current_wave_stress !< Unknown, and presently unused by MOM6
     real,                      optional , intent(in) :: sosga !< Global average sea surface salinity [ppt]
+    real, dimension(ilb:,jlb:),optional,  intent(in) :: geolat
     type(EOS_type),            optional,  intent(in) :: eqn_of_state
   end subroutine generic_tracer_source
 

--- a/config_src/external/GFDL_ocean_BGC/generic_tracer.F90
+++ b/config_src/external/GFDL_ocean_BGC/generic_tracer.F90
@@ -6,7 +6,7 @@ module generic_tracer
 
   use g_tracer_utils, only : g_tracer_type, g_diag_type
 
-  use MOM_variables, only : thermo_var_ptrs
+  use MOM_EOS,           only: EOS_type
 
   implicit none ; private
 
@@ -71,15 +71,13 @@ contains
   end subroutine generic_tracer_coupler_accumulate
 
   !> Calls the corresponding generic_X_update_from_source routine for each package X
-  subroutine generic_tracer_source(Temp,Salt,tv,rho_dzt,dzt,hblt_depth,ilb,jlb,tau,dtts,&
+  subroutine generic_tracer_source(Temp,Salt,rho_dzt,dzt,hblt_depth,ilb,jlb,tau,dtts,&
        grid_dat,model_time,nbands,max_wavelength_band,sw_pen_band,opacity_band,internal_heat,&
-       frunoff,grid_ht, current_wave_stress, sosga)
+       frunoff,grid_ht, current_wave_stress, sosga, eqn_of_state)
     integer,                        intent(in) :: ilb    !< Lower bounds of x extent of input arrays on data domain
     integer,                        intent(in) :: jlb    !< Lower bounds of y extent of input arrays on data domain
     real, dimension(ilb:,jlb:,:),   intent(in) :: Temp   !< Potential temperature [deg C]
     real, dimension(ilb:,jlb:,:),   intent(in) :: Salt   !< Salinity [psu]
-    type(thermo_var_ptrs),          intent(in) :: tv     !< structure containing pointers to available
-                                                         !! thermodynamic fields
     real, dimension(ilb:,jlb:,:),   intent(in) :: rho_dzt !< Mass per unit area of each layer [kg m-2]
     real, dimension(ilb:,jlb:,:),   intent(in) :: dzt    !< Ocean layer thickness [m]
     real, dimension(ilb:,jlb:),     intent(in) :: hblt_depth !< Boundary layer depth [m]
@@ -101,6 +99,7 @@ contains
     real, dimension(ilb:,jlb:),optional,  intent(in) :: grid_ht !< Unknown, and presently unused by MOM6
     real, dimension(ilb:,jlb:),optional , intent(in) :: current_wave_stress !< Unknown, and presently unused by MOM6
     real,                      optional , intent(in) :: sosga !< Global average sea surface salinity [ppt]
+    type(EOS_type),            optional,  intent(in) :: eqn_of_state
   end subroutine generic_tracer_source
 
   !> Update the tracers from bottom fluxes

--- a/config_src/external/GFDL_ocean_BGC/generic_tracer.F90
+++ b/config_src/external/GFDL_ocean_BGC/generic_tracer.F90
@@ -34,8 +34,7 @@ contains
   end subroutine generic_tracer_register
 
   !> Initialize generic tracers
-  subroutine generic_tracer_init(isc,iec,jsc,jec,isd,ied,jsd,jed,nk,ntau,axes,grid_tmask,grid_kmt,init_time, &
-                                 geolon,geolat)
+  subroutine generic_tracer_init(isc,iec,jsc,jec,isd,ied,jsd,jed,nk,ntau,axes,grid_tmask,grid_kmt,init_time)
     integer,                       intent(in) :: isc !< Computation start index in i direction
     integer,                       intent(in) :: iec !< Computation end index in i direction
     integer,                       intent(in) :: jsc !< Computation start index in j direction
@@ -50,8 +49,6 @@ contains
     type(time_type),               intent(in) :: init_time !< Time
     real, dimension(:,:,:),target, intent(in) :: grid_tmask !< Mask
     integer, dimension(:,:)      , intent(in) :: grid_kmt !< Number of wet cells in column
-    real, dimension(:,:),target,   intent(in) :: geolon !< Longitude
-    real, dimension(:,:),target,   intent(in) :: geolat !< Latitude
   end subroutine generic_tracer_init
 
   !> Unknown

--- a/config_src/external/GFDL_ocean_BGC/generic_tracer.F90
+++ b/config_src/external/GFDL_ocean_BGC/generic_tracer.F90
@@ -96,8 +96,8 @@ contains
     real, dimension(ilb:,jlb:),optional,  intent(in) :: grid_ht !< Unknown, and presently unused by MOM6
     real, dimension(ilb:,jlb:),optional , intent(in) :: current_wave_stress !< Unknown, and presently unused by MOM6
     real,                      optional , intent(in) :: sosga !< Global average sea surface salinity [ppt]
-    real, dimension(ilb:,jlb:),optional,  intent(in) :: geolat
-    type(EOS_type),            optional,  intent(in) :: eqn_of_state
+    real, dimension(ilb:,jlb:),optional,  intent(in) :: geolat !< Latitude
+    type(EOS_type),            optional,  intent(in) :: eqn_of_state !< A pointer to the equation of state
   end subroutine generic_tracer_source
 
   !> Update the tracers from bottom fluxes

--- a/config_src/external/GFDL_ocean_BGC/generic_tracer_utils.F90
+++ b/config_src/external/GFDL_ocean_BGC/generic_tracer_utils.F90
@@ -108,8 +108,7 @@ contains
     type(g_diag_ctrl),  target,intent(in) :: diag_CS !< Unknown
   end subroutine g_tracer_set_csdiag
 
-  subroutine g_tracer_set_common(isc,iec,jsc,jec,isd,ied,jsd,jed,nk,ntau,axes,grid_tmask,grid_kmt,init_time, &
-                                 geolon,geolat)
+  subroutine g_tracer_set_common(isc,iec,jsc,jec,isd,ied,jsd,jed,nk,ntau,axes,grid_tmask,grid_kmt,init_time)
     integer,                     intent(in) :: isc !< Computation start index in i direction
     integer,                     intent(in) :: iec !< Computation end index in i direction
     integer,                     intent(in) :: jsc !< Computation start index in j direction
@@ -124,8 +123,6 @@ contains
     real, dimension(isd:,jsd:,:),intent(in) :: grid_tmask !< Unknown
     integer,dimension(isd:,jsd:),intent(in) :: grid_kmt !< Unknown
     type(time_type),             intent(in) :: init_time !< Unknown
-    real, dimension(isd:,jsd:),  intent(in) :: geolon !< Longitude
-    real, dimension(isd:,jsd:),  intent(in) :: geolat !< Latitude
   end subroutine g_tracer_set_common
 
   subroutine g_tracer_get_common(isc,iec,jsc,jec,isd,ied,jsd,jed,nk,ntau,&

--- a/src/tracer/MOM_generic_tracer.F90
+++ b/src/tracer/MOM_generic_tracer.F90
@@ -559,18 +559,18 @@ contains
         (G%US%Q_to_J_kg == 1.0) .and. (G%US%RZ_to_kg_m2 == 1.0) .and. &
         (US%C_to_degC == 1.0) .and. (US%S_to_ppt == 1.0)) then
       ! Avoid unnecessary copies when no unit conversion is needed.
-      call generic_tracer_source(tv%T, tv%S, tv, rho_dzt, dzt, dz_ml, G%isd, G%jsd, 1, dt, &
+      call generic_tracer_source(tv%T, tv%S, rho_dzt, dzt, dz_ml, G%isd, G%jsd, 1, dt, &
                G%areaT, get_diag_time_end(CS%diag), &
                optics%nbands, optics%max_wavelength_band, optics%sw_pen_band, optics%opacity_band, &
-               internal_heat=tv%internal_heat, frunoff=fluxes%frunoff, sosga=sosga)
+               internal_heat=tv%internal_heat, frunoff=fluxes%frunoff, sosga=sosga, eqn_of_state=tv%eqn_of_state)
     else
-      call generic_tracer_source(US%C_to_degC*tv%T, US%S_to_ppt*tv%S, tv, rho_dzt, dzt, dz_ml, G%isd, G%jsd, 1, dt, &
+      call generic_tracer_source(US%C_to_degC*tv%T, US%S_to_ppt*tv%S, rho_dzt, dzt, dz_ml, G%isd, G%jsd, 1, dt, &
                G%US%L_to_m**2*G%areaT(:,:), get_diag_time_end(CS%diag), &
                optics%nbands, optics%max_wavelength_band, &
                sw_pen_band=G%US%QRZ_T_to_W_m2*optics%sw_pen_band(:,:,:), &
                opacity_band=G%US%m_to_Z*optics%opacity_band(:,:,:,:), &
                internal_heat=G%US%RZ_to_kg_m2*US%C_to_degC*tv%internal_heat(:,:), &
-               frunoff=G%US%RZ_T_to_kg_m2s*fluxes%frunoff(:,:), sosga=sosga)
+               frunoff=G%US%RZ_T_to_kg_m2s*fluxes%frunoff(:,:), sosga=sosga, eqn_of_state=tv%eqn_of_state)
     endif
 
     ! This uses applyTracerBoundaryFluxesInOut to handle the change in tracer due to freshwater fluxes

--- a/src/tracer/MOM_generic_tracer.F90
+++ b/src/tracer/MOM_generic_tracer.F90
@@ -94,9 +94,8 @@ contains
   !> Initializes the generic tracer packages and adds their tracers to the list
   !! Adds the tracers in the list of generic tracers to the set of MOM tracers (i.e., MOM-register them)
   !! Register these tracers for restart
-  function register_MOM_generic_tracer(HI, G, GV, param_file, CS, tr_Reg, restart_CS)
+  function register_MOM_generic_tracer(HI, GV, param_file, CS, tr_Reg, restart_CS)
     type(hor_index_type),       intent(in)   :: HI         !< Horizontal index ranges
-    type(ocean_grid_type),      intent(in)   :: G          !< The ocean's grid structure
     type(verticalGrid_type),    intent(in)   :: GV         !< The ocean's vertical grid structure
     type(param_file_type),      intent(in)   :: param_file !< A structure to parse for run-time parameters
     type(MOM_generic_tracer_CS), pointer     :: CS         !< Pointer to the control structure for this module
@@ -177,7 +176,7 @@ contains
     ! Initialize all generic tracers
     !
     call generic_tracer_init(HI%isc,HI%iec,HI%jsc,HI%jec,HI%isd,HI%ied,HI%jsd,HI%jed,&
-         GV%ke,ntau,axes,grid_tmask,grid_kmt,set_time(0,0),G%geolonT,G%geolatT)
+         GV%ke,ntau,axes,grid_tmask,grid_kmt,set_time(0,0))
 
 
     !
@@ -421,7 +420,8 @@ contains
       endif
     enddo ; enddo
     call g_tracer_set_common(G%isc,G%iec,G%jsc,G%jec,G%isd,G%ied,G%jsd,G%jed,&
-                             GV%ke,1,CS%diag%axesTL%handles,grid_tmask,grid_kmt,day,G%geolonT,G%geolatT)
+                             GV%ke,1,CS%diag%axesTL%handles,grid_tmask,grid_kmt,day,&
+                             G%geolonT,G%geolatT)
 
     ! Register generic tracer modules diagnostics
 

--- a/src/tracer/MOM_generic_tracer.F90
+++ b/src/tracer/MOM_generic_tracer.F90
@@ -420,8 +420,7 @@ contains
       endif
     enddo ; enddo
     call g_tracer_set_common(G%isc,G%iec,G%jsc,G%jec,G%isd,G%ied,G%jsd,G%jed,&
-                             GV%ke,1,CS%diag%axesTL%handles,grid_tmask,grid_kmt,day,&
-                             G%geolonT,G%geolatT)
+                             GV%ke,1,CS%diag%axesTL%handles,grid_tmask,grid_kmt,day)
 
     ! Register generic tracer modules diagnostics
 
@@ -562,7 +561,7 @@ contains
       call generic_tracer_source(tv%T, tv%S, rho_dzt, dzt, dz_ml, G%isd, G%jsd, 1, dt, &
                G%areaT, get_diag_time_end(CS%diag), &
                optics%nbands, optics%max_wavelength_band, optics%sw_pen_band, optics%opacity_band, &
-               internal_heat=tv%internal_heat, frunoff=fluxes%frunoff, sosga=sosga, eqn_of_state=tv%eqn_of_state)
+               internal_heat=tv%internal_heat, frunoff=fluxes%frunoff, sosga=sosga, geolat=G%geolatT, eqn_of_state=tv%eqn_of_state)
     else
       call generic_tracer_source(US%C_to_degC*tv%T, US%S_to_ppt*tv%S, rho_dzt, dzt, dz_ml, G%isd, G%jsd, 1, dt, &
                G%US%L_to_m**2*G%areaT(:,:), get_diag_time_end(CS%diag), &
@@ -570,7 +569,7 @@ contains
                sw_pen_band=G%US%QRZ_T_to_W_m2*optics%sw_pen_band(:,:,:), &
                opacity_band=G%US%m_to_Z*optics%opacity_band(:,:,:,:), &
                internal_heat=G%US%RZ_to_kg_m2*US%C_to_degC*tv%internal_heat(:,:), &
-               frunoff=G%US%RZ_T_to_kg_m2s*fluxes%frunoff(:,:), sosga=sosga, eqn_of_state=tv%eqn_of_state)
+               frunoff=G%US%RZ_T_to_kg_m2s*fluxes%frunoff(:,:), sosga=sosga, geolat=G%geolatT, eqn_of_state=tv%eqn_of_state)
     endif
 
     ! This uses applyTracerBoundaryFluxesInOut to handle the change in tracer due to freshwater fluxes

--- a/src/tracer/MOM_tracer_flow_control.F90
+++ b/src/tracer/MOM_tracer_flow_control.F90
@@ -259,7 +259,7 @@ subroutine call_tracer_register(G, GV, US, param_file, CS, tr_Reg, restart_CS)
     register_CFC_cap(G%HI, GV, param_file, CS%CFC_cap_CSp, &
                         tr_Reg, restart_CS)
   if (CS%use_MOM_generic_tracer) CS%use_MOM_generic_tracer = &
-    register_MOM_generic_tracer(G%HI, G, GV, param_file, CS%MOM_generic_tracer_CSp, &
+    register_MOM_generic_tracer(G%HI, GV, param_file, CS%MOM_generic_tracer_CSp, &
                                 tr_Reg, restart_CS)
   if (CS%use_pseudo_salt_tracer) CS%use_pseudo_salt_tracer = &
     register_pseudo_salt_tracer(G%HI, GV, param_file, CS%pseudo_salt_tracer_CSp, &


### PR DESCRIPTION
The [new cobalt-p4](https://github.com/NOAA-CEFI-Regional-Ocean-Modeling/ocean_BGC) requires several variables from MOM6 (e.g. `geolat` for day-length calculation as well as `eqs_of_state` for density calculation).

We revisited the original changes and removed unnecessary changes to minimize the generic tracer interface changes at MOM6 side. The results match those obtained from the original codes in the 1-D and NWA12 RT tests.

Dependency: https://github.com/NOAA-CEFI-Regional-Ocean-Modeling/ocean_BGC/pull/8