### PR TITLE
Temporal fix for slow nudging with FMS2 

### DIFF
--- a/src/framework/MOM_horizontal_regridding.F90
+++ b/src/framework/MOM_horizontal_regridding.F90
@@ -682,18 +682,19 @@ subroutine horiz_interp_and_extrap_tracer_fms_id(field, Time, G, tr_z, mask_z, &
   real :: pole      ! The sum of tracer values at the pole [a]
   real :: max_depth ! The maximum depth of the ocean [Z ~> m]
   real :: npole     ! The number of points contributing to the pole value [nondim]
-  real :: missing_val_in ! The missing value in the input field [a]
+  real, save :: missing_val_in ! The missing value in the input field [a]
   real :: roundoff  ! The magnitude of roundoff, usually ~2e-16 [nondim]
   logical :: add_np
   type(horiz_interp_type) :: Interp
-  type(axis_info), dimension(4) :: axes_data
+  type(axis_info), save, dimension(4) :: axes_data
   integer :: is, ie, js, je     ! compute domain indices
   integer :: isg, ieg, jsg, jeg ! global extent
   integer :: isd, ied, jsd, jed ! data domain indices
   integer :: id_clock_read
-  integer, dimension(4) :: fld_sz
+  integer, save, dimension(4) :: fld_sz
   logical :: debug=.false.
   logical :: is_ongrid
+  logical, save :: first_time = .true.
   integer :: ans_date           ! The vintage of the expressions and order of arithmetic to use
   real :: I_scale               ! The inverse of the scale factor for diagnostic output [a A-1 ~> 1]
   real :: dtr_iter_stop         ! The tolerance for changes in tracer concentrations between smoothing
@@ -735,7 +736,10 @@ subroutine horiz_interp_and_extrap_tracer_fms_id(field, Time, G, tr_z, mask_z, &
 
   call cpu_clock_begin(id_clock_read)
 
-  call get_external_field_info(field, size=fld_sz, axes=axes_data, missing=missing_val_in)
+  if (first_time) then
+    call get_external_field_info(field, size=fld_sz, axes=axes_data, missing=missing_val_in)
+    first_time = .false.
+  endif !first_time
   missing_value = scale*missing_val_in
 
   verbosity = MOM_get_verbosity()


### PR DESCRIPTION
It has been reported from our seasonal prediction workflow that the current MOM6 nudging cycle is much slower with FMS2:


With FMS1:
```
                                                       hits          tmin          tmax          tavg                tstd           tfrac    grain pemin pemax
(Ocean sponges)                         48      1.046542      3.557714      1.843401      0.315346  0.008    31             0     1645
```

With FMS2:
```
                                                       hits          tmin          tmax          tavg                tstd           tfrac    grain pemin pemax
(Ocean sponges)                         48    197.205940    199.744052    198.060822      0.332912  0.402    31     0  1645
```

Through deeper investigation, I found that for whatever reason, the `get_external_field_info` function called by `horiz_interp_and_extrap_tracer_fms_id` is significantly slower with FMS2. Since the field name and axes size are static, there is no need to re-fetch all this information for every time step. 

This PR introduces a new logic `first_time` in the `get_external_field_info` function so that it gets axes info only at the first step. 

Please note that this is just a temporary fix (which is why I chose to merge it to our dev/cefi branch first); we still need to investigate further to determine the root cause of why the `get_external_field_info` function is much slower with FMS2. In the meantime, this PR can make the model run with FMS2 at almost the same speed as with FMS1 (only 0.03% slower in a one-year run, see below profiling). 

FMS2 with new fix one year run:
```
                                      hits          tmin          tmax          tavg          tstd  tfrac grain pemin pemax
Total runtime                            1   9425.780744   9425.898127   9425.820889      0.036968  1.000     0     0  1645
(Ocean sponges)                      17520    445.104094   1139.163714    580.620263     63.931211  0.062    31     0  1645
```

FMS1 with new fix one year run:
```
                                      hits          tmin          tmax          tavg          tstd  tfrac grain pemin pemax
Total runtime                            1   9400.495175   9400.592062   9400.525483      0.031271  1.000     0     0  1645
(Ocean sponges)                      17520    446.976279   1156.951049    594.715797     65.370447  0.063    31     0  1645
```


Once it merges, we can start using the new diag manager and sub-regional output that are offered by FMS2.