### PR TITLE
Rename vertdiff_G routines to just vertdiff

### DIFF
--- a/config_src/external/GFDL_ocean_BGC/generic_tracer.F90
+++ b/config_src/external/GFDL_ocean_BGC/generic_tracer.F90
@@ -20,7 +20,7 @@ module generic_tracer
   public generic_tracer_end
   public generic_tracer_get_list
   public do_generic_tracer
-  public generic_tracer_vertdiff_G
+  public generic_tracer_vertdiff
   public generic_tracer_get_diag_list
   public generic_tracer_coupler_accumulate
 
@@ -108,7 +108,7 @@ contains
   end subroutine generic_tracer_update_from_bottom
 
   !> Vertically diffuse all generic tracers for GOLD ocean
-  subroutine generic_tracer_vertdiff_G(h_old, ea, eb, dt, kg_m2_to_H, m_to_H, tau)
+  subroutine generic_tracer_vertdiff(h_old, ea, eb, dt, kg_m2_to_H, m_to_H, tau)
     real, dimension(:,:,:), intent(in) :: h_old  !< Layer thickness before entrainment [H ~> m or kg m-2]
     real, dimension(:,:,:), intent(in) :: ea     !< The amount of fluid entrained from the layer
                                                  !! above during this call [H ~> m or kg m-2]
@@ -120,7 +120,7 @@ contains
     real,                   intent(in) :: m_to_H !< A unit conversion factor from heights to
                                                  !! thickness units [H m-1 ~> 1 or kg m-3]
     integer,                intent(in) :: tau    !< The time level to work on (always 1 for MOM6)
-  end subroutine generic_tracer_vertdiff_G
+  end subroutine generic_tracer_vertdiff
 
   !> Set the coupler values for each generic tracer
   subroutine generic_tracer_coupler_set(IOB_struc, ST,SS,rho,ilb,jlb,tau, dzt, sosga,model_time)

--- a/config_src/external/GFDL_ocean_BGC/generic_tracer_utils.F90
+++ b/config_src/external/GFDL_ocean_BGC/generic_tracer_utils.F90
@@ -334,7 +334,7 @@ contains
   !!  for a tracer node.This is ported from GOLD (vertdiff) and simplified
   !! Since the surface flux from the atmosphere (%stf) has the units of mol/m^2/sec the resulting
   !!  tracer concentration has units of mol/Kg
-  subroutine g_tracer_vertdiff_G(g_tracer, h_old, ea, eb, dt, kg_m2_to_H, m_to_H, tau, mom)
+  subroutine g_tracer_vertdiff(g_tracer, h_old, ea, eb, dt, kg_m2_to_H, m_to_H, tau, mom)
     type(g_tracer_type),    pointer  :: g_tracer !< Unknown
     !> Layer thickness before entrainment, in m or kg m-2.
     real, dimension(g_tracer_com%isd:,g_tracer_com%jsd:,:), intent(in) :: h_old
@@ -349,6 +349,6 @@ contains
                                    !! of h_old (H).
     integer,  intent(in) :: tau !< Unknown
     logical,  intent(in), optional :: mom !< Unknown
-  end subroutine g_tracer_vertdiff_G
+  end subroutine g_tracer_vertdiff
 
 end module g_tracer_utils

--- a/src/tracer/MOM_generic_tracer.F90
+++ b/src/tracer/MOM_generic_tracer.F90
@@ -20,7 +20,7 @@ module MOM_generic_tracer
   use generic_tracer, only: generic_tracer_init, generic_tracer_source, generic_tracer_register_diag
   use generic_tracer, only: generic_tracer_coupler_get, generic_tracer_coupler_set
   use generic_tracer, only: generic_tracer_end, generic_tracer_get_list, do_generic_tracer
-  use generic_tracer, only: generic_tracer_update_from_bottom,generic_tracer_vertdiff_G
+  use generic_tracer, only: generic_tracer_update_from_bottom,generic_tracer_vertdiff
   use generic_tracer, only: generic_tracer_coupler_accumulate
 
   use g_tracer_utils,   only: g_tracer_get_name,g_tracer_set_values,g_tracer_set_common,g_tracer_get_common
@@ -620,10 +620,10 @@ contains
     ! surface source is applied and diapycnal advection and diffusion occurs.
     if (present(evap_CFL_limit) .and. present(minimum_forcing_depth)) then
       ! Last arg is tau which is always 1 for MOM6
-      call generic_tracer_vertdiff_G(h_work, ea, eb, US%T_to_s*dt, GV%kg_m2_to_H, GV%m_to_H, 1)
+      call generic_tracer_vertdiff(h_work, ea, eb, US%T_to_s*dt, GV%kg_m2_to_H, GV%m_to_H, 1)
     else
       ! Last arg is tau which is always 1 for MOM6
-      call generic_tracer_vertdiff_G(h_old, ea, eb, US%T_to_s*dt, GV%kg_m2_to_H, GV%m_to_H, 1)
+      call generic_tracer_vertdiff(h_old, ea, eb, US%T_to_s*dt, GV%kg_m2_to_H, GV%m_to_H, 1)
     endif
 
     ! Update bottom fields after vertical processes


### PR DESCRIPTION
Needed to work with the corresponding change to ocean_BGC that removes the vertdiff_M routines and also renames vertdiff_G to just vertdiff. 