### PR TITLE
Dirty fix to recover reproducibility across restart when OBC segment dt is larger than DT_therm.

### DIFF
--- a/config_src/external/GFDL_ocean_BGC/generic_tracer.F90
+++ b/config_src/external/GFDL_ocean_BGC/generic_tracer.F90
@@ -6,6 +6,8 @@ module generic_tracer
 
   use g_tracer_utils, only : g_tracer_type, g_diag_type
 
+  use MOM_EOS,           only: EOS_type
+
   implicit none ; private
 
   public generic_tracer_register
@@ -68,7 +70,7 @@ contains
   !> Calls the corresponding generic_X_update_from_source routine for each package X
   subroutine generic_tracer_source(Temp,Salt,rho_dzt,dzt,hblt_depth,ilb,jlb,tau,dtts,&
        grid_dat,model_time,nbands,max_wavelength_band,sw_pen_band,opacity_band,internal_heat,&
-       frunoff,grid_ht, current_wave_stress, sosga)
+       frunoff,grid_ht, current_wave_stress, sosga, geolat, eqn_of_state)
     integer,                        intent(in) :: ilb    !< Lower bounds of x extent of input arrays on data domain
     integer,                        intent(in) :: jlb    !< Lower bounds of y extent of input arrays on data domain
     real, dimension(ilb:,jlb:,:),   intent(in) :: Temp   !< Potential temperature [deg C]
@@ -94,6 +96,8 @@ contains
     real, dimension(ilb:,jlb:),optional,  intent(in) :: grid_ht !< Unknown, and presently unused by MOM6
     real, dimension(ilb:,jlb:),optional , intent(in) :: current_wave_stress !< Unknown, and presently unused by MOM6
     real,                      optional , intent(in) :: sosga !< Global average sea surface salinity [ppt]
+    real, dimension(ilb:,jlb:),optional,  intent(in) :: geolat !< Latitude
+    type(EOS_type),            optional,  intent(in) :: eqn_of_state !< A pointer to the equation of state
   end subroutine generic_tracer_source
 
   !> Update the tracers from bottom fluxes

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2859,9 +2859,16 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   endif
 
   if (associated(CS%OBC)) then
+    ! If the dt of OBC segment updates for OBGC is longer than dt_therm, the OBC inflow conc 
+    ! will be saved in restart to ensure reproducibility across restarts.
+    ! CS%OBC%level_count controls the size of the 5th dimension of tres_x or tres_y
+    ! The default value is 1 for saving tracer reservoir, and 2 is for saving tracer inflow conc
+    if (CS%dt_obc_seg_period > CS%dt_therm) CS%OBC%inflow_conc_restart = .true.
+    if (CS%OBC%inflow_conc_restart) CS%OBC%level_count = 2
+      
     ! Set up remaining information about open boundary conditions that is needed for OBCs.
     call call_OBC_register(G, GV, US, param_file, CS%update_OBC_CSp, CS%OBC, CS%tracer_Reg)
-  !### Package specific changes to OBCs need to go here?
+    !### Package specific changes to OBCs need to go here?
 
     ! This is the equivalent to 2 calls to register_segment_tracer (per segment), which
     ! could occur with the call to update_OBC_data or after the main initialization.

--- a/src/tracer/MOM_generic_tracer.F90
+++ b/src/tracer/MOM_generic_tracer.F90
@@ -582,7 +582,8 @@ contains
       call generic_tracer_source(tv%T, tv%S, rho_dzt, dzt, dz_ml, G%isd, G%jsd, 1, dt, &
                G%areaT, get_diag_time_end(CS%diag), &
                optics%nbands, optics%max_wavelength_band, optics%sw_pen_band, optics%opacity_band, &
-               internal_heat=tv%internal_heat, frunoff=fluxes%frunoff, sosga=sosga)
+               internal_heat=tv%internal_heat, frunoff=fluxes%frunoff, sosga=sosga, &
+               geolat=G%geolatT, eqn_of_state=tv%eqn_of_state)
     else
       call generic_tracer_source(US%C_to_degC*tv%T, US%S_to_ppt*tv%S, rho_dzt, dzt, dz_ml, G%isd, G%jsd, 1, dt, &
                G%US%L_to_m**2*G%areaT(:,:), get_diag_time_end(CS%diag), &
@@ -590,7 +591,8 @@ contains
                sw_pen_band=G%US%QRZ_T_to_W_m2*optics%sw_pen_band(:,:,:), &
                opacity_band=G%US%m_to_Z*optics%opacity_band(:,:,:,:), &
                internal_heat=G%US%RZ_to_kg_m2*US%C_to_degC*tv%internal_heat(:,:), &
-               frunoff=G%US%RZ_T_to_kg_m2s*fluxes%frunoff(:,:), sosga=sosga)
+               frunoff=G%US%RZ_T_to_kg_m2s*fluxes%frunoff(:,:), sosga=sosga, &
+               geolat=G%geolatT, eqn_of_state=tv%eqn_of_state)
     endif
 
     ! This uses applyTracerBoundaryFluxesInOut to handle the change in tracer due to freshwater fluxes

--- a/src/tracer/MOM_generic_tracer.F90
+++ b/src/tracer/MOM_generic_tracer.F90
@@ -585,7 +585,10 @@ contains
                internal_heat=tv%internal_heat, frunoff=fluxes%frunoff, sosga=sosga, &
                geolat=G%geolatT, eqn_of_state=tv%eqn_of_state)
     else
-      call generic_tracer_source(US%C_to_degC*tv%T, US%S_to_ppt*tv%S, rho_dzt, dzt, dz_ml, G%isd, G%jsd, 1, dt, &
+      ! tv%internal_heat is a null pointer unless DO_GEOTHERMAL = True,
+      ! so we have to check and only do the scaling if it is associated.
+      if(associated(tv%internal_heat)) then
+        call generic_tracer_source(US%C_to_degC*tv%T, US%S_to_ppt*tv%S, rho_dzt, dzt, dz_ml, G%isd, G%jsd, 1, dt, &
                G%US%L_to_m**2*G%areaT(:,:), get_diag_time_end(CS%diag), &
                optics%nbands, optics%max_wavelength_band, &
                sw_pen_band=G%US%QRZ_T_to_W_m2*optics%sw_pen_band(:,:,:), &
@@ -593,6 +596,15 @@ contains
                internal_heat=G%US%RZ_to_kg_m2*US%C_to_degC*tv%internal_heat(:,:), &
                frunoff=G%US%RZ_T_to_kg_m2s*fluxes%frunoff(:,:), sosga=sosga, &
                geolat=G%geolatT, eqn_of_state=tv%eqn_of_state)
+      else
+        call generic_tracer_source(US%C_to_degC*tv%T, US%S_to_ppt*tv%S, rho_dzt, dzt, dz_ml, G%isd, G%jsd, 1, dt, &
+               G%US%L_to_m**2*G%areaT(:,:), get_diag_time_end(CS%diag), &
+               optics%nbands, optics%max_wavelength_band, &
+               sw_pen_band=G%US%QRZ_T_to_W_m2*optics%sw_pen_band(:,:,:), &
+               opacity_band=G%US%m_to_Z*optics%opacity_band(:,:,:,:), &
+               frunoff=G%US%RZ_T_to_kg_m2s*fluxes%frunoff(:,:), sosga=sosga, &
+               geolat=G%geolatT, eqn_of_state=tv%eqn_of_state)
+      endif
     endif
 
     ! This uses applyTracerBoundaryFluxesInOut to handle the change in tracer due to freshwater fluxes


### PR DESCRIPTION
This PR addresses the reproducibility issue across restarts when `DT_OBC_SEG_UPDATE_OBGC` is larger than `DT_THERM`. When users set a value of `DT_OBC_SEG_UPDATE_OBGC` that is larger than `DT_THERM`, the inflow concentrations for OBC tracers will be saved and reused in subsequent restart runs. No answers change happened in this PR except we will dump more variables in restart when `DT_OBC_SEG_UPDATE_OBGC > DT_THERM`.

While this quick fix resolves the issue, it has some drawbacks. Specifically, **it significantly increases the restart size (e.g., approximately 40% increase for the NEP domain)** while providing less than a 10% performance gain when `DT_OBC_SEG_UPDATE_OBGC` >= 3600s (see table below).

**Updates**: I conducted five additional sensitivity experiments for the NWA12 domain (see the second table below). The results align closely with those from the NEP domain. We achieved optimal runtime reduction by setting `DT_OBC_SEG_UPDATE_OBGC = DT_THERM`. Further increasing `DT_OBC_SEG_UPDATE_OBGC` only yielded a slight runtime reduction (~2% additional decrease).

**Based on sensitivity experiments, it appears that the optimal configuration for `DT_OBC_SEG_UPDATE_OBGC` is to set it equal to `DT_THERM`. I would recommend for our regional configuration that we at least set `DT_OBC_SEG_UPDATE_OBGC = DT_THERM` to save runtime while maintaining reproducibility and a reasonable restart file size.**

**Runtime of NEP10 1-year simulation (hrs):** 
| | **FMS1**       | **FMS2**               |    | 
|-----------------------|-----------------------------|-----------------------------|-----------------------------|
| **DT_OBC_seg = 400s**           |                          |       8.1               |                    |
| **DT_OBC_seg = 1200s**         |           6.7         |       6.6               |        -18.52%             |
| **DT_OBC_seg = 3600s**         |          6.2          |       6.1              |          -24.69%            |
| **DT_OBC_seg = 7200s**         |                         |       6.0              |           -25.92%           |


**Runtime of NWA12 1-year simulation (hrs):** 
| | **FMS1**       |               |
|-----------------------|-----------------------------|-----------------------------
| **DT_OBC_seg = 600s**           |           8.71               |                    |
| **DT_OBC_seg = 1800s**         |           7.54         |         -13.43%            |
| **DT_OBC_seg = 3600s**         |           7.37         |         -15.38%       |
| **DT_OBC_seg = 5400s**         |          7.22         |          -17.11%           | 
| **DT_OBC_seg = 7200s**         |           7.20              |      -17.34%              |


We could consider merging this fix into our `dev/cefi repo` (probably not the dev/gfdl because I am not completely satisfied with this fix) to ensure code reproducibility even with super large `DT_OBC_SEG_UPDATE_OBGC` values. We should eventually revisit the OBC_segment_update source code to find a better solution for improving performance.

CC @charliestock , @andrew-c-ross, @theresa-morrison, @amoebaliz, @gabyneg, @uwagura    
